### PR TITLE
暗号化(Brypt)

### DIFF
--- a/api/domain/user.go
+++ b/api/domain/user.go
@@ -1,10 +1,11 @@
 package domain
 
 import (
-	"crypto/sha1"
 	"errors"
 	"fmt"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/go-playground/validator/v10"
 )
@@ -21,9 +22,15 @@ type User struct {
 
 type Users []User
 
-func (u User) Encrypt(plaintext string) (cryptext string) {
-	cryptext = fmt.Sprintf("%x", sha1.Sum([]byte(plaintext)))
-	return cryptext
+func (u User) Encrypt(plaintext string) (hash string) {
+	byteHash, _ := bcrypt.GenerateFromPassword([]byte(plaintext), bcrypt.DefaultCost)
+	// if err != nil {
+	// 	fmt.Println(err)
+	// 	log.Println(err)
+	// 	return "", err
+	// }
+	hash = string(byteHash)
+	return hash
 }
 
 func traslateUsersField(field string) (value string) {

--- a/api/go.mod
+++ b/api/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/gorilla/sessions v1.2.1 // indirect
 	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/rs/cors v1.8.2
+	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	gopkg.in/ini.v1 v1.66.3
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -39,8 +39,12 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220214200702-86341886e292 h1:f+lwQ+GtmgoY+A2YaQxlSOnDjXcQ7ZRLWOHbC6HtRqE=
+golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 h1:siQdpVirKtzPhKl3lZWozZraCFObP8S1v6PRp0bLrtU=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/api/infrastructure/router.go
+++ b/api/infrastructure/router.go
@@ -11,13 +11,12 @@ import (
 )
 
 func Init() {
+	log.SetFlags(log.Ltime | log.Llongfile)
 	err := godotenv.Load("env/dev.env")
 	if err != nil {
-		log.SetFlags(log.Llongfile)
+		log.Println(err)
 		log.Panicln(err)
 	}
-
-	log.SetFlags(log.Ltime | log.Llongfile)
 
 	r := mux.NewRouter()
 	todoController := controllers.NewTodoController(NewSqlHandler())

--- a/api/interfaces/controllers/user_controller.go
+++ b/api/interfaces/controllers/user_controller.go
@@ -18,7 +18,7 @@ type UserController struct {
 }
 
 type UserValidError struct {
-	Detail string
+	Error string
 }
 
 func NewUserController(sqlHandler database.SqlHandler) *UserController {
@@ -48,7 +48,7 @@ func (controller *UserController) Create(w http.ResponseWriter, r *http.Request)
 		errStr := err.Error()
 		errStr1 := strings.Replace(errStr, "Error 1062: Duplicate entry", "入力された", 1)
 		errStr2 := strings.Replace(errStr1, "for key 'email'", "既に登録されています。", 1)
-		validErr := &UserValidError{Detail: errStr2}
+		validErr := &UserValidError{Error: errStr2}
 		e, _ := json.Marshal(validErr)
 		fmt.Fprintln(w, string(e))
 		return

--- a/api/interfaces/database/user_repositoryl.go
+++ b/api/interfaces/database/user_repositoryl.go
@@ -12,7 +12,6 @@ type UserRepository struct {
 }
 
 func (repo *UserRepository) Store(u domain.User) (id int, err error) {
-	cryptext := u.Encrypt(u.Password)
 	result, err := repo.Execute(`
 		insert into
 			users(
@@ -22,7 +21,7 @@ func (repo *UserRepository) Store(u domain.User) (id int, err error) {
 				created_at
 			)
 		values (?, ?, ?, ?)
-	`, u.Name, u.Email, cryptext, time.Now())
+	`, u.Name, u.Email, u.Password, time.Now())
 	if err != nil {
 		log.SetFlags(log.Llongfile)
 		log.Println(err)

--- a/api/usecase/session/session_interactor.go
+++ b/api/usecase/session/session_interactor.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"log"
 
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/kory-jp/react_golang_mux/api/domain"
 )
 
@@ -20,12 +22,18 @@ func (interactor *SessionInteractor) Login(u domain.User) (user domain.User, err
 	if err != nil {
 		log.SetFlags(log.Llongfile)
 		log.Println(err)
-		err = errors.New("メールアドレスに一致するユーザーがおりません")
+		err = errors.New("認証に失敗しました")
 	} else {
-		if userFindByEmail.Password == u.Encrypt(u.Password) {
+		// if userFindByEmail.Password == u.Encrypt(u.Password) {
+		// 	user = userFindByEmail
+		// } else {
+		// 	err = errors.New("認証に失敗しました")
+		// }
+		err = bcrypt.CompareHashAndPassword([]byte(userFindByEmail.Password), []byte(u.Password))
+		if err == nil {
 			user = userFindByEmail
 		} else {
-			err = errors.New("パスワードが一致しませんでした")
+			err = errors.New("認証に失敗しました")
 		}
 	}
 	return

--- a/api/usecase/user/user_interactor.go
+++ b/api/usecase/user/user_interactor.go
@@ -12,6 +12,7 @@ type UserInteractor struct {
 
 func (interactor *UserInteractor) Add(u domain.User) (user domain.User, err error) {
 	if err = u.UserValidate(); err == nil {
+		u.Password = u.Encrypt(u.Password)
 		identifier, validErr := interactor.UserRepository.Store(u)
 		err = validErr
 		if err != nil {

--- a/client/client-app/src/reducks/users/opretions.ts
+++ b/client/client-app/src/reducks/users/opretions.ts
@@ -35,8 +35,9 @@ export const saveUserInfo = (name: string, email: string, password: string, pass
           }
         }
       ).then((response) => {
-        if (response.data.Detail) {
-          dispatch(pushToast({title: response.data.Detail, severity: "error"}))
+        console.log(response)
+        if (response.data.Error) {
+          dispatch(pushToast({title: response.data.Error, severity: "error"}))
           return
         } else {
           const userData: User = response.data.user
@@ -74,8 +75,8 @@ export const login = (email: string, password: string) => {
           }
         }
       ).then((response) => {
-        if (response.data.Detail) {
-          dispatch(pushToast({title: response.data.Detail, severity: "error"}))
+        if (response.data.Error) {
+          dispatch(pushToast({title: response.data.Error, severity: "error"}))
           return
         } else {
           const userData: User = response.data
@@ -102,9 +103,9 @@ export const isLoggedIn = () => {
           }
         }
       ).then((response) => {
-        if (response.data.Detail) {
+        if (response.data.Error) {
           dispatch(push("/"))
-          dispatch(pushToast({title: response.data.Detail, severity: "error"}))
+          dispatch(pushToast({title: response.data.Error, severity: "error"}))
           return
         } else {
           const userData: User = response.data

--- a/mysql/initdb.d/init.sql
+++ b/mysql/initdb.d/init.sql
@@ -2,7 +2,7 @@ create table if not exists users (
 	id integer primary key auto_increment,
 	name varchar(50) NOT NULL,
 	email varchar(50) NOT NULL UNIQUE,
-	password varchar(50) NOT NULL,
+	password varchar(60) NOT NULL,
 	created_at datetime default current_timestamp
 );
 


### PR DESCRIPTION
### api

- 暗号化を`sha1`から`bcypt`へ変更
- `token`作成にかかるエラーハンドリングを追加
- `userId`を取得する関数を共通化＋取得に失敗した場合のエラーハンドリングを追加

### mysql

- hash化された暗号を保存するためにユーザーのパスワードの文字数を60文字に変更

