### PR TITLE
一覧ページのデザイン作成

### DIFF
--- a/api/interfaces/database/todos/mysql/mysql.go
+++ b/api/interfaces/database/todos/mysql/mysql.go
@@ -52,7 +52,7 @@ var GetTodosState = `
 		t.id
 	order by
 		id desc
-	limit 5
+	limit 6
 	offset ?
 `
 

--- a/api/interfaces/database/todos/todo_repository.go
+++ b/api/interfaces/database/todos/todo_repository.go
@@ -91,14 +91,14 @@ func (repo *TodoRepository) FindByUserId(identifier int, page int) (todos domain
 	row.Close()
 
 	// データ総数を1ページに表示したい件数を割り、ページ総数を算出
-	sumPage = math.Ceil(allTodosCount / 5)
+	sumPage = math.Ceil(allTodosCount / 6)
 	// ---
 
 	var offsetNum int
 	if page == 1 {
 		offsetNum = 0
 	} else {
-		offsetNum = (page - 1) * 5
+		offsetNum = (page - 1) * 6
 	}
 	rows, err := repo.Query(mysql.GetTodosState, identifier, offsetNum)
 	if err != nil {

--- a/client/client-app/src/components_ver2/molecules/pagination/DefaultPagination.tsx
+++ b/client/client-app/src/components_ver2/molecules/pagination/DefaultPagination.tsx
@@ -1,0 +1,31 @@
+import { Pagination } from "@mui/material";
+import { Box } from "@mui/system";
+import { FC } from "react";
+
+
+type Props = {
+  count: number,
+  onChange: (event: React.ChangeEvent<unknown>, page: number) => void,
+  page: number
+}
+
+export const DefaultPagination: FC<Props> = (props) => {
+  const {count, onChange, page} = props
+  return(
+    <Box
+      marginTop="30px"
+      display="flex"
+      justifyContent="space-around"
+    >
+      <Pagination 
+        count={count}
+        onChange={onChange}
+        page={page}
+        variant="outlined"
+        // color="secondary"
+      />
+    </Box>
+  )
+}
+
+export default DefaultPagination;

--- a/client/client-app/src/components_ver2/molecules/tag/TagSelection.tsx
+++ b/client/client-app/src/components_ver2/molecules/tag/TagSelection.tsx
@@ -1,0 +1,65 @@
+import { VFC } from 'react';
+import Select from 'react-select'
+
+interface Tag {
+  id: number;
+  value: string;
+  label: string;
+}
+
+type Props = {
+  placeholder: string
+  isMulti: boolean
+  options: Tag[]
+  onChange: (event:any) => void
+  values?: Tag[]
+  value?: Tag
+}
+
+const customStyles = {
+  control: (base: any) => ({
+    ...base,
+    background: "#605D5D",
+    color: '#FFF',
+    fontSize: '14px',
+    minWidth: "280px",
+  }),
+  placeholder: (defaultStyles: any) => {
+    return {
+      ...defaultStyles,
+      color: "#FFF"
+    }
+  },
+  singleValue: (base: any) => ({
+    ...base,
+    color: "#FFF",
+  })
+};
+
+export const TagSelection: VFC<Props> = (props) => {
+  const {placeholder, isMulti, onChange, options, values, value} = props
+
+  if (isMulti) {
+    return(
+      <Select 
+        placeholder={placeholder}
+        isMulti
+        options={options}
+        onChange={onChange}
+        value={values}
+      />
+    )
+  } else {
+    return(
+      <Select 
+        placeholder={placeholder}
+        options={options}
+        onChange={onChange}
+        value={value}
+        styles={customStyles}
+      />
+    )
+  }
+}
+
+export default TagSelection; 

--- a/client/client-app/src/components_ver2/organisms/layout/Header.tsx
+++ b/client/client-app/src/components_ver2/organisms/layout/Header.tsx
@@ -10,6 +10,7 @@ import { isLoggedIn, logout } from "../../../reducks/users/opretions";
 import Toast from "../../molecules/toast/Toast";
 import DefautlDrawer from "../../molecules/drawer/DefaultDrawer";
 import { RootState } from "../../../reducks/store/store";
+import { push } from "connected-react-router";
 
 export const Header: FC = () => {
   const dispatch = useDispatch()
@@ -19,6 +20,10 @@ export const Header: FC = () => {
   useEffect(() => {
     dispatch(isLoggedIn())
   },[])
+
+  const onClickToTop = useCallback(() => {
+    dispatch(push("/todo"))
+  }, [])
 
   // --------
   const onClickOpen = useCallback(() => {
@@ -72,8 +77,12 @@ export const Header: FC = () => {
                 },
                 paddingY: {
                   xs: '24px',
+                },
+                ":hover": {
+                  cursor: 'pointer',
                 }
               }}
+              onClick={onClickToTop}
             >
               <CardMedia 
                 component="img"
@@ -114,7 +123,7 @@ export const Header: FC = () => {
               </Box>
               <Box>
                 <PrimaryButton
-                  onClick={onClickOpen}
+                  onClick={onClickLogout}
                 >
                   ログアウト
                 </PrimaryButton>

--- a/client/client-app/src/components_ver2/organisms/layout/SearchSection.tsx
+++ b/client/client-app/src/components_ver2/organisms/layout/SearchSection.tsx
@@ -1,0 +1,112 @@
+import { Grid } from "@mui/material";
+import { Box } from "@mui/system";
+import { push } from "connected-react-router";
+import { FC, useCallback, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "../../../reducks/store/store";
+import { indexTags } from "../../../reducks/tags/operations";
+import { Tag, Tags } from "../../../reducks/tags/types";
+import { Todo } from "../../../reducks/todos/types";
+import { makeOptions } from "../../../utils/makeOptions";
+import { PrimaryButton } from "../../atoms/buttons/PrimaryButton";
+import TagSelection from "../../molecules/tag/TagSelection";
+
+export const SearchSection: FC = () => {
+  const dispatch = useDispatch()
+  const [tag, setTag] = useState(0)
+  const [importance, setImportance] = useState(0)
+  const [urgency, setUrgency] = useState(0)  
+
+  useEffect(() => {
+    dispatch(indexTags())
+  }, [])
+
+  const options: Tags = useSelector((state: RootState) => state.tags)
+  const { importanceOptions, urgencyOptions } = makeOptions()
+
+  const onChangeSelectTags = useCallback((event: Tag) => {
+    setTag(event.id)
+  }, [setTag])
+
+  const onChangeImportance = useCallback((event: Todo) => {
+    setImportance(event.id)
+  }, [setImportance])
+
+  const onChangeUrgency = useCallback((event: Todo) => {
+    setUrgency(event.id)
+  }, [setUrgency])
+
+  const onClickToSearchPage = useCallback(() => {
+    dispatch(push(`/todo/search?tagId=${tag}&importance=${importance}&urgency=${urgency}`))
+  },[tag, importance, urgency])
+
+  return(
+    <>
+      <Box
+        bgcolor='#2D2A2A'
+        sx={{
+          paddingY: {
+            xs: '24px',
+          },
+          paddingX: {
+            xs: '16px',
+          },
+        }}
+        borderRadius='10px'
+      >
+        <Grid
+          container
+          spacing={2}
+          sx={{
+            justifyContent: {
+              xs: 'center',
+              sm: 'center',
+              md: 'center',
+              lg: 'space-between',
+            }
+          }}
+        >
+          <Grid item>
+            <TagSelection 
+              placeholder={'タグを選択してください'}
+              isMulti={false}
+              options={options}
+              onChange={onChangeSelectTags}
+            />
+          </Grid>
+          <Grid item>
+            <TagSelection 
+              placeholder={'重要度を選択してください'}
+              isMulti={false}
+              options={importanceOptions}
+              onChange={onChangeImportance}
+            />
+          </Grid>
+          <Grid item>
+            <TagSelection 
+              placeholder={'緊急度を選択してください'}
+              isMulti={false}
+              options={urgencyOptions}
+              onChange={onChangeUrgency}
+            />
+          </Grid>
+          <Grid item>
+            <Box
+              sx={{
+                minWidth: '280px',
+              }}
+            >
+              <PrimaryButton
+                onClick={onClickToSearchPage}
+              >
+                検索
+              </PrimaryButton>              
+            </Box>
+          </Grid>
+        </Grid>
+      </Box>
+    </>
+  )
+}
+
+export default SearchSection;

--- a/client/client-app/src/components_ver2/organisms/toods/DefaultIndexSection.tsx
+++ b/client/client-app/src/components_ver2/organisms/toods/DefaultIndexSection.tsx
@@ -1,0 +1,74 @@
+import { Grid } from "@mui/material";
+import { Box } from "@mui/system";
+import { FC } from "react";
+import { Todos } from "../../../reducks/todos/types";
+import LoadingLayout from "../../molecules/loading/LoadingLayout";
+import DefaultPagination from "../../molecules/pagination/DefaultPagination";
+import TodoCard from "./TodoCard";
+
+type Props = {
+  todos: Todos,
+  sumPage: number,
+  setSumPage: React.Dispatch<React.SetStateAction<number>>,
+  queryPage: number,
+  loadingState: boolean,
+  onChangeCurrentPage: (event: React.ChangeEvent<unknown>, page: number) => void,
+}
+
+export const DefaultIndexSection: FC<Props> = (props) => {
+  const {todos, sumPage, setSumPage, queryPage, loadingState, onChangeCurrentPage} = props
+
+  return(
+    <>
+      {
+        loadingState ? (
+          <LoadingLayout />
+        ) : (
+          <Box>
+            {
+              todos != null && todos.length > 0 && (
+                <Grid
+                  container
+                  spacing={4}
+                  sx={{
+                    justifyContent: {
+                      md: 'space-between'
+                    }
+                  }}
+                >
+                  {
+                    todos.map (todo => (
+                      <Grid
+                        item
+                        key={todo.id}
+                        sx={{
+                          width: {
+                            xs: '100%',
+                            md: 'auto',
+                          }
+                        }}
+                      >
+                        <TodoCard 
+                          todo={todo}
+                          setSumPage={setSumPage}
+                          queryPage={queryPage}
+                        />
+                      </Grid>
+                    ))
+                  }
+                </Grid>
+              )
+            }
+          <DefaultPagination 
+            count={sumPage}
+            onChange={onChangeCurrentPage}
+            page={queryPage}
+          />
+          </Box>
+        )
+      }
+    </>
+  )
+}
+
+export default DefaultIndexSection;

--- a/client/client-app/src/components_ver2/organisms/toods/SearchIndexSection.tsx
+++ b/client/client-app/src/components_ver2/organisms/toods/SearchIndexSection.tsx
@@ -1,27 +1,33 @@
 import { push } from "connected-react-router";
 import { FC, useCallback, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-
+import { useLocation } from "react-router-dom";
 import useLoadingState from "../../../hooks/useLoadingState";
 import usePagination from "../../../hooks/usePagination";
 import { RootState } from "../../../reducks/store/store";
-import { indexTodos } from "../../../reducks/todos/operations";
+import { search } from "../../../reducks/todos/operations";
 import { Todos } from "../../../reducks/todos/types";
 import DefaultIndexSection from "./DefaultIndexSection";
 
-export const IndexSection: FC = () => {
+export const SearchIndexSection: FC = () => {
   const dispatch = useDispatch()
   const loadingState = useLoadingState()
   const {sumPage, setSumPage, queryPage} = usePagination()
-  
-  useEffect(() => {
-    dispatch(indexTodos(setSumPage, queryPage))
-  }, [setSumPage, queryPage])
-  const todos: Todos = useSelector((state: RootState) => state.todos)
 
+  const query =  new URLSearchParams(useLocation().search)
+  const tagId = Number(query.get("tagId"))
+  const importance = Number(query.get("importance"))
+  const urgency = Number(query.get("urgency"))
+
+  useEffect(()=> {
+    dispatch(search(tagId, importance, urgency, queryPage, setSumPage))
+  },[tagId, importance, urgency, queryPage])
+
+  const todos: Todos = useSelector((state: RootState) => state.todos)
+  
   const onChangeCurrentPage = useCallback((event: React.ChangeEvent<unknown>, page: number) => {
-    dispatch(push(`/todo?page=${page}`))
-  }, [])
+    dispatch(push(`/todo/search?tagId=${tagId}&importance=${importance}&urgency=${urgency}&page=${page}`))
+  }, [tagId, importance, urgency])
 
   return(
     <>
@@ -37,4 +43,4 @@ export const IndexSection: FC = () => {
   )
 }
 
-export default IndexSection;
+export default SearchIndexSection;

--- a/client/client-app/src/components_ver2/organisms/toods/TodoCard.tsx
+++ b/client/client-app/src/components_ver2/organisms/toods/TodoCard.tsx
@@ -59,6 +59,10 @@ export const TodoCard: FC<Props> = (props) => {
           transition: '0.7s',
           bgcolor: finish? 'text.disabled' : '#2D2A2A',
           borderRadius: '10px',
+          width: {
+            md: '360px',
+            xl: '400px',
+          }
         }}
       >
         {/* ----- 画像セクション ----- */}
@@ -183,25 +187,6 @@ export const TodoCard: FC<Props> = (props) => {
             {handleToDateFormat(todo.createdAt)}
           </Box>
         </CardContent>
-        {/* --- tagzone --- */}
-        {/* {
-            tags != null && (
-              <Grid container>
-                {tags.map(tag => (
-                  <Grid
-                    key={tag.id}
-                    marginLeft="10px"
-                    marginY="20px"
-                  >
-                    <PrimaryChip 
-                      label={tag.label}
-                      onClick={() => onClickToSearchTagTodo(tag.id)}
-                    />
-                  </Grid>
-                ))}
-              </Grid>
-            )
-          } */}
           <Grid
             container
             sx={{

--- a/client/client-app/src/components_ver2/organisms/users/LoginSection.tsx
+++ b/client/client-app/src/components_ver2/organisms/users/LoginSection.tsx
@@ -44,7 +44,7 @@ export const LoginSection:FC = () => {
         >
 
           <Typography
-            variant="h1"
+          component='h1'
             color="#FFF"
             fontFamily="Noto Serif JP, serif;"
             sx={{

--- a/client/client-app/src/components_ver2/pages/todos/SearchTodos.tsx
+++ b/client/client-app/src/components_ver2/pages/todos/SearchTodos.tsx
@@ -1,0 +1,12 @@
+import { FC } from "react";
+import SearchTodosTemplate from "../../template/todos/SearchTodosTemplate";
+
+export const SearchTodos: FC = () => {
+  return (
+    <>
+      <SearchTodosTemplate />
+    </>
+  )
+}
+
+export default SearchTodos;

--- a/client/client-app/src/components_ver2/template/todos/DefaultIndexTemplate.tsx
+++ b/client/client-app/src/components_ver2/template/todos/DefaultIndexTemplate.tsx
@@ -1,0 +1,66 @@
+import { Box } from "@mui/system";
+import { FC, ReactNode } from "react";
+import SearchSection from "../../organisms/layout/SearchSection";
+import DefaultTemplate from "./DefaultTemplate";
+
+type Props = {
+  children: ReactNode
+}
+
+export const DefaultIndexTemplate: FC<Props> = (props) => {
+  const {children} = props
+
+  return(
+    <>
+      <DefaultTemplate>
+        <Box
+          sx={{
+            marginBottom: {
+              xs: '40px',
+            },
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          <Box
+            sx={{
+              width: {
+                xs: '95%',
+                sm: '90%',
+                md: '85%',
+                lg: '80%',
+              }
+            }}
+          >
+           <SearchSection />
+          </Box>
+        </Box>
+        <Box
+          sx={{
+            marginBottom: {
+              xs: '40px',
+            },
+            display: 'flex',
+            justifyContent: 'center',
+          }}          
+        >
+          <Box
+            sx={{
+              width: {
+                xs: '95%',
+                sm: '90%',
+                md: '85%',
+                lg: '80%',
+              },
+            }}
+          >
+            {/* <IndexSection /> */}
+            {children}
+          </Box>
+        </Box>
+      </DefaultTemplate>
+    </>
+  )
+}
+
+export default DefaultIndexTemplate

--- a/client/client-app/src/components_ver2/template/todos/DefaultTemplate.tsx
+++ b/client/client-app/src/components_ver2/template/todos/DefaultTemplate.tsx
@@ -12,16 +12,64 @@ export const DefaultTemplate: VFC<Props> = (props) => {
 
   return (
     <>
-      <Header />
-      {children}
       <Box
+        id="content_header"
+        component="header"
+        bgcolor="#2D2A2A"
+        display='flex'
+        justifyContent='center'
         sx={{
-          position: 'absolute',
-          bottom: '0',
-          width: '100%',
+          marginBottom: {
+            xs: '40px',
+          }
         }}
       >
-        <Footer />
+        <Box
+          sx={{
+            width: {
+              xs: '95%',
+              sm: '90%',
+              md: '85%',
+              lg: '80%',
+            }
+          }}
+        >
+          <Header />
+        </Box>
+      </Box>
+      <Box
+        id="content_main"
+        component="main"
+        sx={{
+          // --- フッター下部に固定 ---
+          flexFlow: 'column',
+          minHeight: '100vh'
+        }}
+      >
+        {children}
+      </Box>
+      <Box
+        id="content_footer"
+        component="footer"
+        sx={{
+          width: '100%',
+          bgcolor: "#2D2A2A",
+          display: 'flex',
+          justifyContent: 'center',
+        }}
+      >
+        <Box
+          sx={{
+            width: {
+              xs: '95%',
+              sm: '90%',
+              md: '85%',
+              lg: '80%',
+            }            
+          }}
+        >
+          <Footer />
+        </Box>
       </Box>
     </>
   )

--- a/client/client-app/src/components_ver2/template/todos/IndexTodosTemplate.tsx
+++ b/client/client-app/src/components_ver2/template/todos/IndexTodosTemplate.tsx
@@ -1,13 +1,13 @@
 import { FC } from "react";
 import IndexSection from "../../organisms/toods/IndexSection";
-import DefaultTemplate from "./DefaultTemplate";
+import DefaultIndexTemplate from "./DefaultIndexTemplate";
 
 export const IndexTodosTemplate: FC = () => {
   return(
     <>
-      <DefaultTemplate>
+      <DefaultIndexTemplate>
         <IndexSection />
-      </DefaultTemplate>
+      </DefaultIndexTemplate>
     </>
   )
 }

--- a/client/client-app/src/components_ver2/template/todos/SearchTodosTemplate.tsx
+++ b/client/client-app/src/components_ver2/template/todos/SearchTodosTemplate.tsx
@@ -1,0 +1,15 @@
+import { FC } from "react";
+import SearchIndexSection from "../../organisms/toods/SearchIndexSection";
+import DefaultIndexTemplate from "./DefaultIndexTemplate";
+
+export const SearchTodosTemplate: FC = () => {
+  return(
+    <>
+      <DefaultIndexTemplate>
+        <SearchIndexSection />
+      </DefaultIndexTemplate>
+    </>
+  )
+}
+
+export default SearchTodosTemplate

--- a/client/client-app/src/components_ver2/template/users/DefaultTemplate.tsx
+++ b/client/client-app/src/components_ver2/template/users/DefaultTemplate.tsx
@@ -4,6 +4,7 @@ import { ReactNode, VFC } from "react";
 import TopImage from "../../atoms/images/TopImage";
 import Footer from "../../organisms/layout/Footer";
 import AppLogo from "../../../assets/images/AppLogo.svg"
+import Toast from "../../molecules/toast/Toast";
 
 type Props = {
   children: ReactNode
@@ -133,6 +134,7 @@ export const DefaultTemplate: VFC<Props> = (props) => {
           <Footer />
         </Box>
       </Box>
+      <Toast />
     </>
   )
 }

--- a/client/client-app/src/router/Router.tsx
+++ b/client/client-app/src/router/Router.tsx
@@ -9,7 +9,8 @@ import EditTodo from "../components/pages/todos/EditTodo";
 // import IndexTodos from "../components/pages/todos/IndexTodos";
 import IndexTodos from "../components_ver2/pages/todos/IndexTodos";
 import NewTodo from "../components/pages/todos/NewTodo";
-import SearchTodos from "../components/pages/todos/SearchTodos";
+// import SearchTodos from "../components/pages/todos/SearchTodos";
+import SearchTodos from "../components_ver2/pages/todos/SearchTodos";
 import ShowTodo from "../components/pages/todos/ShowTodo";
 
 export const Router: FC = () => {


### PR DESCRIPTION
- indexページ
- searchIndexページ
- ページごとの取得件数を5件から6件に変更
- ページネーションコンポーネントを追加
- ヘッダーからトップページへ遷移可能