### PR TITLE
Fargateを用いたデプロイに関連した変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ api/__debug_bin
 
 ## other
 .vscode/
+infra/

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,1 @@
+client-app/node_modules

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,16 +1,15 @@
-FROM node:16-alpine
-# RUN mkdir -p /app/client/client-app
-# WORKDIR /app/client/client-app
-# COPY client-app/package.json .
-# COPY client-app/tsconfig.json .
-# COPY client-app/yarn.lock .
-# RUN yarn install --production
-# COPY . .
-# EXPOSE 3000
-# CMD ["yarn", "build"]
-
+FROM node:16-alpine as builder
 RUN mkdir -p /app/client
 WORKDIR /app/client
-COPY ./client-app .
+
+COPY ./client-app/package.json .
+COPY ./client-app/yarn.lock .
+COPY ./client-app/tsconfig.json .
+RUN yarn install --production
+COPY ./client-app/ .
+RUN yarn build
+
+FROM nginx
+COPY --from=builder /app/client/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/nginx.conf
 EXPOSE 3000
-CMD ["yarn", "build"]

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,17 @@
+events {
+}
+
+http {
+  include /etc/nginx/mime.types;
+
+  server {
+    listen 3000;
+    # Dockerfileでreactのbuildフォルダを格納しているパス
+    root /usr/share/nginx/html;
+
+    location / {
+      # $uri = /
+      try_files $uri $uri/ /index.html;
+    }
+  }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -5,6 +5,7 @@ events {
 }
 
 http {
+
   server {
     listen 80;
 


### PR DESCRIPTION
## 質問概要

現在、`Fargate`を用いてデプロイをしようと作業を進めております。
そのため、関連する`Dockerfile`の新規作成、変更、また`Nginx`の設定ファイルの修正をおこなっております。
一旦、`Client(React)`側の`Fargate`上での最低限の起動を確認できたのですが、変更点に関してなにかお気づきの点がございましたら是非アドバイスを頂戴できれば幸いです。
(パブリックIDからの表示の確認はできましたが、現在は料金の関係からタスクを終了しております。)

<br>

主な変更ファイル

- nginx/Dockerfile
- nginx/nginx.conf
- client/Dockerfile
- client/nginx.conf

<br>

## 現在のAWS構築

*コンテナを起動させるための試験的な構成になっており、この後、大きく変更をして参ります。

<br>

![infra](https://user-images.githubusercontent.com/66899822/168774798-cd9f9f37-fcdc-4c6a-8dcc-57432460619a.png)

<br>

## 解説

セキュリティグループで外部からのアクセスは80番ポートに限定
`client/nginx.conf+Dockerfile`にて80番ポートからのアクセスを受け取る
`nginx.conf`内の`location / {}`にて3000番ポートの`client`へ通信を振り分ける
https://github.com/kory-jp/react_golang_mux/tree/feature_1.2.0.7/fargate/nginx

`client`以下の`Dockerfile`にて本番用のビルドを実行、`nginx.conf`にてビューの表示
https://github.com/kory-jp/react_golang_mux/tree/feature_1.2.0.7/fargate/client

<br>